### PR TITLE
Make test parameters context managers

### DIFF
--- a/haas_rest_test/parameter_builder.py
+++ b/haas_rest_test/parameter_builder.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2014 Simon Jagoe and Enthought Ltd.
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the 3-clause BSD license.  See the LICENSE.txt file for details.
+from __future__ import absolute_import, unicode_literals
+
+from contextlib import contextmanager
+
+from haas_rest_test.utils import ExitStack
+from .plugins.test_parameters import HeadersTestParameter
+
+
+@contextmanager
+def ParameterBuilder(config, parameter_loaders):
+    try:
+        headers_loader = next(loader for loader in parameter_loaders
+                              if isinstance(loader, HeadersTestParameter))
+    except StopIteration:
+        headers_loader = None
+    parameter_loaders = [loader for loader in parameter_loaders
+                         if loader is not headers_loader]
+
+    all_headers = {}
+    parameters_dict = {  # Parameter defaults
+        'method': 'GET',
+    }
+
+    with ExitStack() as stack:
+        for parameter_loader in parameter_loaders:
+            loaded = stack.enter_context(parameter_loader.load(config))
+            all_headers.update(loaded.pop('headers', {}))
+            parameters_dict.update(loaded)
+
+        if headers_loader is not None:
+            headers = stack.enter_context(headers_loader.load(config))
+            all_headers.update(headers.get('headers', {}))
+
+        parameters_dict['headers'] = all_headers
+        yield parameters_dict

--- a/haas_rest_test/plugins/i_test_parameter.py
+++ b/haas_rest_test/plugins/i_test_parameter.py
@@ -23,14 +23,17 @@ class ITestParameter(object):
     """
 
     @abstractclassmethod
-    def from_dict(cls):
+    def from_dict(cls, data):
         """Create the TestParameter from a dictionary.
 
         """
 
     @abc.abstractmethod
     def load(self, config):
-        """Load and return the options to pass to
+        """Context manager to load and return the options to pass to
         ``requests.Session.request()``.
+
+        On context cleanup, this context manager is expected to release
+        any resources helf during the HTTP request.
 
         """

--- a/haas_rest_test/plugins/test_parameters.py
+++ b/haas_rest_test/plugins/test_parameters.py
@@ -6,6 +6,7 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
+from contextlib import contextmanager
 import json
 
 from jsonschema.exceptions import ValidationError
@@ -44,8 +45,9 @@ class MethodTestParameter(ITestParameter):
             raise YamlParseError(str(e))
         return cls(method=data['method'])
 
+    @contextmanager
     def load(self, config):
-        return {self.name: self.method}
+        yield {self.name: self.method}
 
 
 class HeadersTestParameter(ITestParameter):
@@ -76,12 +78,13 @@ class HeadersTestParameter(ITestParameter):
             raise YamlParseError(str(e))
         return cls(headers=data['headers'])
 
+    @contextmanager
     def load(self, config):
         headers = dict(
             (header_name, config.load_variable(header_name, header_value))
             for header_name, header_value in self.headers.items()
         )
-        return {self.name: headers}
+        yield {self.name: headers}
 
 
 class BodyTestParameter(ITestParameter):
@@ -164,6 +167,7 @@ class BodyTestParameter(ITestParameter):
             value=body['value'],
         )
 
+    @contextmanager
     def load(self, config):
         result = {}
         format = self._format
@@ -180,4 +184,4 @@ class BodyTestParameter(ITestParameter):
 
         result['data'] = value
 
-        return result
+        yield result

--- a/haas_rest_test/plugins/tests/test_test_parameters.py
+++ b/haas_rest_test/plugins/tests/test_test_parameters.py
@@ -25,10 +25,9 @@ class TestMethodTestParameter(unittest.TestCase):
         parameter = MethodTestParameter.from_dict(spec)
 
         # When
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, spec)
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, spec)
 
     def test_invalid_method(self):
         # Given
@@ -56,10 +55,9 @@ class TestHeadersTestParameter(unittest.TestCase):
         parameter = HeadersTestParameter.from_dict(spec)
 
         # When
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, spec)
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, spec)
 
     def test_load_variable(self):
         # Given
@@ -82,11 +80,10 @@ class TestHeadersTestParameter(unittest.TestCase):
         parameter = HeadersTestParameter.from_dict(spec)
         expected = {'headers': {'Content-Type': 'application/json'}}
 
-        # When/Then
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, expected)
+        # When
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, expected)
 
     def test_load_missing_variable(self):
         # Given
@@ -103,7 +100,8 @@ class TestHeadersTestParameter(unittest.TestCase):
 
         # When/Then
         with self.assertRaises(InvalidVariable):
-            parameter.load(config)
+            with parameter.load(config):
+                pass
 
 
 class TestBodyTestParameter(unittest.TestCase):
@@ -133,10 +131,9 @@ class TestBodyTestParameter(unittest.TestCase):
         }
 
         # When
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, expected)
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, expected)
 
     def test_body_yaml(self):
         # Given
@@ -161,10 +158,9 @@ class TestBodyTestParameter(unittest.TestCase):
         }
 
         # When
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, expected)
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, expected)
 
     def test_body_plain(self):
         # Given
@@ -182,10 +178,9 @@ class TestBodyTestParameter(unittest.TestCase):
         }
 
         # When
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, expected)
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, expected)
 
     def test_body_format_none(self):
         # Given
@@ -203,10 +198,9 @@ class TestBodyTestParameter(unittest.TestCase):
         }
 
         # When
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, expected)
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, expected)
 
     def test_body_from_var(self):
         # Given
@@ -231,7 +225,6 @@ class TestBodyTestParameter(unittest.TestCase):
         }
 
         # When
-        loaded = parameter.load(config)
-
-        # Then
-        self.assertEqual(loaded, expected)
+        with parameter.load(config) as loaded:
+            # Then
+            self.assertEqual(loaded, expected)

--- a/haas_rest_test/tests/test_web_test.py
+++ b/haas_rest_test/tests/test_web_test.py
@@ -35,6 +35,10 @@ class TestWebTest(unittest.TestCase):
             'method': MethodTestParameter,
         }
 
+    def _get_web_test_method(self, web_test):
+        with web_test.test_parameters() as test_parameters:
+            return test_parameters['method']
+
     def test_from_dict(self):
         # Given
         config = Config.from_dict({'host': 'test.invalid'}, __file__)
@@ -65,7 +69,7 @@ class TestWebTest(unittest.TestCase):
         self.assertIs(test.config, config)
         self.assertEqual(test.name, name)
         self.assertEqual(test.url, expected_url)
-        self.assertEqual(test.method, 'GET')
+        self.assertEqual(self._get_web_test_method(test), 'GET')
         self.assertEqual(len(test.assertions), 0)
 
     def test_from_different_method(self):
@@ -99,7 +103,7 @@ class TestWebTest(unittest.TestCase):
         self.assertIs(test.config, config)
         self.assertEqual(test.name, name)
         self.assertEqual(test.url, expected_url)
-        self.assertEqual(test.method, 'POST')
+        self.assertEqual(self._get_web_test_method(test), 'POST')
         self.assertEqual(len(test.assertions), 0)
 
     def test_create_with_assertions(self):
@@ -183,7 +187,7 @@ class TestWebTest(unittest.TestCase):
             self.test_parameter_plugins)
 
         responses.add(
-            test.method,
+            self._get_web_test_method(test),
             test.url,
             status=204,
         )

--- a/haas_rest_test/utils.py
+++ b/haas_rest_test/utils.py
@@ -6,6 +6,8 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
+import sys
+
 from requests.utils import default_user_agent as requests_user_agent
 import requests
 
@@ -21,3 +23,143 @@ def create_session():
     session = requests.Session()
     session.headers['User-Agent'] = haas_rest_test_user_agent()
     return session
+
+
+if sys.version_info >= (3, 3):  # pragma: no cover
+    from contextlib import ExitStack  # noqa
+else:  # pragma: no cover
+    from collections import deque
+
+    # Copied from Python 3.4.1 contextlib
+    class ExitStack(object):
+        """Context manager for dynamic management of a stack of exit callbacks
+
+        For example:
+
+            with ExitStack() as stack:
+                files = [stack.enter_context(open(fname)) for fname in filenames]
+                # All opened files will automatically be closed at the end of
+                # the with statement, even if attempts to open files later
+                # in the list raise an exception
+
+        """  # noqa
+        def __init__(self):
+            self._exit_callbacks = deque()
+
+        def pop_all(self):
+            """Preserve the context stack by transferring it to a new instance
+            """
+            new_stack = type(self)()
+            new_stack._exit_callbacks = self._exit_callbacks
+            self._exit_callbacks = deque()
+            return new_stack
+
+        def _push_cm_exit(self, cm, cm_exit):
+            """Helper to correctly register callbacks to __exit__ methods"""
+            def _exit_wrapper(*exc_details):
+                return cm_exit(cm, *exc_details)
+            _exit_wrapper.__self__ = cm
+            self.push(_exit_wrapper)
+
+        def push(self, exit):
+            """Registers a callback with the standard __exit__ method signature
+
+            Can suppress exceptions the same way __exit__ methods can.
+
+            Also accepts any object with an __exit__ method (registering a call
+            to the method instead of the object itself)
+            """
+            # We use an unbound method rather than a bound method to follow
+            # the standard lookup behaviour for special methods
+            _cb_type = type(exit)
+            try:
+                exit_method = _cb_type.__exit__
+            except AttributeError:
+                # Not a context manager, so assume its a callable
+                self._exit_callbacks.append(exit)
+            else:
+                self._push_cm_exit(exit, exit_method)
+            return exit  # Allow use as a decorator
+
+        def callback(self, callback, *args, **kwds):
+            """Registers an arbitrary callback and arguments.
+
+            Cannot suppress exceptions.
+            """
+            def _exit_wrapper(exc_type, exc, tb):
+                callback(*args, **kwds)
+            # We changed the signature, so using @wraps is not appropriate, but
+            # setting __wrapped__ may still help with introspection
+            _exit_wrapper.__wrapped__ = callback
+            self.push(_exit_wrapper)
+            return callback  # Allow use as a decorator
+
+        def enter_context(self, cm):
+            """Enters the supplied context manager
+
+            If successful, also pushes its __exit__ method as a callback and
+            returns the result of the __enter__ method.
+            """
+            # We look up the special methods on the type to match the
+            # with statement
+            _cm_type = type(cm)
+            _exit = _cm_type.__exit__
+            result = _cm_type.__enter__(cm)
+            self._push_cm_exit(cm, _exit)
+            return result
+
+        def close(self):
+            """Immediately unwind the context stack"""
+            self.__exit__(None, None, None)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_details):
+            received_exc = exc_details[0] is not None
+
+            # We manipulate the exception state so it behaves as though
+            # we were actually nesting multiple with statements
+            frame_exc = sys.exc_info()[1]
+
+            def _fix_exception_context(new_exc, old_exc):
+                # Context may not be correct, so find the end of the chain
+                while 1:
+                    exc_context = new_exc.__context__
+                    if exc_context is old_exc:
+                        # Context is already set correctly (see issue 20317)
+                        return
+                    if exc_context is None or exc_context is frame_exc:
+                        break
+                    new_exc = exc_context
+                # Change the end of the chain to point to the exception
+                # we expect it to reference
+                new_exc.__context__ = old_exc
+
+            # Callbacks are invoked in LIFO order to match the behaviour of
+            # nested context managers
+            suppressed_exc = False
+            pending_raise = False
+            while self._exit_callbacks:
+                cb = self._exit_callbacks.pop()
+                try:
+                    if cb(*exc_details):
+                        suppressed_exc = True
+                        pending_raise = False
+                        exc_details = (None, None, None)
+                except:
+                    new_exc_details = sys.exc_info()
+                    # simulate the stack of exceptions by setting the context
+                    _fix_exception_context(new_exc_details[1], exc_details[1])
+                    pending_raise = True
+                    exc_details = new_exc_details
+            if pending_raise:
+                try:
+                    # bare "raise exc_details[1]" replaces our carefully
+                    # set-up context
+                    fixed_ctx = exc_details[1].__context__
+                    raise exc_details[1]
+                except BaseException:
+                    exc_details[1].__context__ = fixed_ctx
+                    raise
+            return received_exc and suppressed_exc


### PR DESCRIPTION
Allows adding test parameters that use resources requiring cleanup.  For
example, a test parameter for file upload will need to open the file for
the duration of the HTTP request and make sure it is closed after the request.
